### PR TITLE
Update dependencies

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,0 +1,42 @@
+From f501e1325bc97a85900f8b29120cf48ac4d258aa Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 17 Nov 2024 21:12:35 +0300
+Subject: [PATCH] Fix appdata papercuts
+
+---
+ data/net.kirgroup.confy.metainfo.xml.in |  9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/data/net.kirgroup.confy.metainfo.xml.in b/data/net.kirgroup.confy.metainfo.xml.in
+index ec020e5..ef4ff52 100644
+--- a/data/net.kirgroup.confy.metainfo.xml.in
++++ b/data/net.kirgroup.confy.metainfo.xml.in
+@@ -20,21 +20,20 @@
+ 	<project_license>GPL-3.0-or-later</project_license>
+ 	<url type="homepage">https://confy.kirgroup.net</url>
+ 	<url type="bugtracker">https://todo.sr.ht/~fabrixxm/confy</url>
+-	<project_group>GNOME</project_group>
++    <url type="vcs-browser">https://git.sr.ht/~fabrixxm/confy/tree</url>
+ 	<screenshots>
+ 		<screenshot type="default">
+-			<image xml:lang="en">https://confy.kirgroup.net/appdata/confy1.png</image>
++			<image>https://confy.kirgroup.net/appdata/confy1.png</image>
+ 		</screenshot>
+ 		<screenshot>
+-			<image xml:lang="en">https://confy.kirgroup.net/appdata/confy2.png</image>
++			<image>https://confy.kirgroup.net/appdata/confy2.png</image>
+ 		</screenshot>
+ 		<screenshot>
+-			<image xml:lang="en">https://confy.kirgroup.net/appdata/confy3.png</image>
++			<image>https://confy.kirgroup.net/appdata/confy3.png</image>
+ 		</screenshot>
+ 	</screenshots>
+ 	<content_rating type="oars-1.1"/>
+ 	<custom>
+-		<value key="Purism::form_factor">workstation</value>
+ 		<value key="Purism::form_factor">mobile</value>
+ 	</custom>
+ 	<supports>
+--
+libgit2 1.7.2
+

--- a/net.kirgroup.confy.json
+++ b/net.kirgroup.confy.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.kirgroup.confy",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "confy",
     "finish-args": [
@@ -13,7 +13,7 @@
         "--talk-name=org.freedesktop.Notifications"
     ],
     "modules": [
-        {
+	{
             "name": "blueprint",
             "buildsystem": "meson",
             "cleanup": [
@@ -23,12 +23,12 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.8.1",
-                    "commit": "aa7679618e864748f4f4d8f15283906e712752fe"
+                    "tag": "v0.14.0",
+                    "commit": "8e10fcf8692108b9d4ab78f41086c5d7773ef864"
                 }
             ]
         },
-        "python3-icalendar.json",
+	"python3-icalendar.json",
         {
             "name": "confy",
             "buildsystem": "meson",
@@ -38,8 +38,12 @@
                     "url": "https://git.sr.ht/~fabrixxm/confy",
                     "tag": "0.7.1",
                     "commit": "8e3785e0c0c359eea4c21ebd7904ec953681ec22"
-                }
-            ]
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-appdata.patch"
+		}
+	    ]
         }
     ]
 }

--- a/python3-icalendar.json
+++ b/python3-icalendar.json
@@ -2,38 +2,23 @@
     "name": "python3-icalendar",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"icalendar\""
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"icalendar\" --no-build-isolation"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/aa/d4/0089d680a610c7b5afda26c1ae588eb363b9050ccf5f33a8c2d1164210f3/setuptools-51.1.2-py3-none-any.whl",
-            "sha256": "67d8af2fc9f33e48f8f4387321700a79b27090a5cff154e5ce1a8c72c2eea54f"
+            "url": "https://files.pythonhosted.org/packages/a5/b5/276bf1e5d0433144b27f707c40afe79e7e8863806837f42956053840a078/icalendar-6.1.0-py3-none-any.whl",
+            "sha256": "46c09b774a6e6948495dafcb166dc15135c8259d0ae25491f154cbc822714b69"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/65/63/39d04c74222770ed1589c0eaba06c05891801219272420b40311cd60c880/wheel-0.36.2-py2.py3-none-any.whl",
-            "sha256": "78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e"
+            "url": "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+            "sha256": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/db/6e/2815f7c8561b088ccedc128681e64daac3d6b2e81a9918b007e244dad8b1/setuptools_scm-5.0.1-py2.py3-none-any.whl",
-            "sha256": "62fa535edb31ece9fa65dc9dcb3056145b8020c8c26c0ef1018aef33db95c40d"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/be/ed/5bbc91f03fa4c839c4c7360375da77f9659af5f7086b7a7bdda65771c8e0/python-dateutil-2.8.1.tar.gz",
-            "sha256": "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/70/44/404ec10dca553032900a65bcded8b8280cf7c64cc3b723324e2181bf93c9/pytz-2020.5.tar.gz",
-            "sha256": "180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
-        },
-        {
-            "type": "file",
-            "url": "https://files.pythonhosted.org/packages/58/b8/9aa7963f442b2a8bfdfc40eab8bc399c5eaac5711b8919c52122e4903544/icalendar-4.0.7.tar.gz",
-            "sha256": "0fc18d87f66e0b5da84fa731389496cfe18e4c21304e8f6713556b2e8724a7a4"
+            "url": "https://files.pythonhosted.org/packages/a6/ab/7e5f53c3b9d14972843a647d8d7a853969a58aecc7559cb3267302c94774/tzdata-2024.2-py2.py3-none-any.whl",
+            "sha256": "a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"
         }
     ]
 }


### PR DESCRIPTION
- update GNOME runtime to 47 (as 45 is outdated by now)
- update blueprint-compiler to 0.14.0
- update python3-icalendar.json
- integrate fix-appdata.patch from #8 to make this pass CI and make an update on flathub possible before another upstream release is ready.

I have confirmed that the buid works locally and the app is functional when rebuild with these changes. 

My reasoning for doing this despite the downstream appdata patch is that conferences keep happening, and it would be great to have an installable build of Confy (without EOL runtimes) on flathub in the meantime.

Hope it helps!